### PR TITLE
Add dummy environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+APP_ID=1234
+WEBHOOK_SECRET=foo
+LOG_LEVEL=debug
+PRIVATE_KEY_PATH=private-key.pem

--- a/private-key.pem
+++ b/private-key.pem
@@ -1,0 +1,1 @@
+I'm not a real key, but Probot will start anyway.


### PR DESCRIPTION
This adds a dummy environment which won't connect to Github, but is sufficient for Probot to start up in the normal mode and then encounter the error we're seeking to debug.
<img width="937" alt="image" src="https://user-images.githubusercontent.com/10095474/167022751-abcb25d1-e2f3-4ff7-8c56-fba7552f6665.png">
